### PR TITLE
Nix Updates and Improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,16 +71,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1742751704,
+        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -83,8 +83,6 @@
             ";
 
             nativeBuildInputs = commonNativeBuildInputs;
-            cargoExtraArgs = "--features xmlsec";
-            cargoTestExtraArgs = "--features xmlsec";
           };
           # Build *just* the cargo dependencies, so we can reuse
           # all of that work (e.g. via cachix) when running in CI

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
     rust-overlay = {
@@ -32,7 +32,7 @@
               nix-filter = nix-filter.lib;
               rust-toolchain = pkgs.rust-bin.stable.latest.default;
               rust-dev-toolchain = pkgs.rust-toolchain.override {
-                extensions = [ "rust-src" ];
+                extensions = [ "rust-src" "rust-analyzer" ];
               };
             })
           ];
@@ -42,16 +42,18 @@
           craneLib =
             (crane.mkLib pkgs).overrideToolchain pkgs.rust-toolchain;
           lib = pkgs.lib;
-          stdenv = pkgs.stdenv;
           commonNativeBuildInputs = with pkgs; [
+            rustPlatform.bindgenHook
+            pkg-config
+          ];
+          commonBuildInputs = with pkgs;[
             libiconv
             libtool
             libxml2
             libxslt
-            llvmPackages.libclang
-            openssl
-            pkg-config
             xmlsec
+            openssl
+            llvmPackages.libclang
           ];
           fixtureFilter = path: _type:
             builtins.match ".*test_vectors.*" path != null ||
@@ -65,24 +67,8 @@
           commonArgs = {
             inherit src;
 
-            # Need to tell bindgen where to find libclang
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-            # Set C flags for Rust's bindgen program. Unlike ordinary C
-            # compilation, bindgen does not invoke $CC directly. Instead it
-            # uses LLVM's libclang. To make sure all necessary flags are
-            # included we need to look in a few places.
-            # See https://web.archive.org/web/20220523141208/https://hoverbear.org/blog/rust-bindgen-in-nix/
-            BINDGEN_EXTRA_CLANG_ARGS = "${builtins.readFile "${stdenv.cc}/nix-support/libc-crt1-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/cc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libcxx-cxxflags"} \
-                -idirafter ${pkgs.libiconv}/include \
-                ${lib.optionalString stdenv.cc.isClang "-idirafter ${stdenv.cc.cc}/lib/clang/${lib.getVersion stdenv.cc.cc}/include"} \
-                ${lib.optionalString stdenv.cc.isGNU "-isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc} -isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/${stdenv.hostPlatform.config} -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include"} \
-            ";
-
             nativeBuildInputs = commonNativeBuildInputs;
+            buildInputs = commonBuildInputs;
           };
           # Build *just* the cargo dependencies, so we can reuse
           # all of that work (e.g. via cachix) when running in CI
@@ -91,30 +77,13 @@
             inherit cargoArtifacts;
           });
         in
-        rec {
+        {
           # `nix build`
           packages.default = samael;
 
           # `nix develop`
           devShells.default = pkgs.mkShell {
-            # Need to tell bindgen where to find libclang
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-            # Set C flags for Rust's bindgen program. Unlike ordinary C
-            # compilation, bindgen does not invoke $CC directly. Instead it
-            # uses LLVM's libclang. To make sure all necessary flags are
-            # included we need to look in a few places.
-            # See https://web.archive.org/web/20220523141208/https://hoverbear.org/blog/rust-bindgen-in-nix/
-            BINDGEN_EXTRA_CLANG_ARGS = "${builtins.readFile "${stdenv.cc}/nix-support/libc-crt1-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/cc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libcxx-cxxflags"} \
-                -idirafter ${pkgs.libiconv}/include \
-                ${lib.optionalString stdenv.cc.isClang "-idirafter ${stdenv.cc.cc}/lib/clang/${lib.getVersion stdenv.cc.cc}/include"} \
-                ${lib.optionalString stdenv.cc.isGNU "-isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc} -isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/${stdenv.hostPlatform.config} -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include"} \
-            ";
-
-            buildInputs = with pkgs; [ rust-dev-toolchain nixpkgs-fmt ];
+            buildInputs = with pkgs; [ rust-dev-toolchain nixpkgs-fmt ] ++ commonBuildInputs;
             nativeBuildInputs = commonNativeBuildInputs;
             shellHook = ''
               export DIRENV_LOG_FORMAT=""


### PR DESCRIPTION
A few changes:

* bump the nixpkgs version to 24.11. We may want to set this to nixpkgs-unstable instead to be more automatically up-to-date?
* Add rust-analyzer to the dev toolchain
* Split the common/native build inputs properly
* Drop the bindngen environment variables in favor of the nixpkgs-provided hook

Note that unit tests will fail on this branch until #4  is merged.