### PR TITLE
Fix for xmlsec 1.3 changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,12 +646,19 @@ dependencies = [
  "pkg-config",
  "quick-xml",
  "rand",
+ "semver",
  "serde",
  "thiserror",
  "url",
  "urlencoding",
  "uuid",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 [build-dependencies]
 bindgen = "^0.69.1"
 pkg-config = "^0.3.17"
+semver = "1.0.26"
 
 [dependencies]
 base64 = "^0.22.0"

--- a/bindings.rs
+++ b/bindings.rs
@@ -4,6 +4,7 @@
 use bindgen::Builder as BindgenBuilder;
 
 use pkg_config::Config as PkgConfig;
+use semver::Version;
 
 use std::env;
 use std::path::PathBuf;
@@ -28,44 +29,63 @@ fn main() {
         false
     };
 
-    // if !dynamic {
-    // }
+    if fetch_xmlsec_version()
+        >= (Version {
+            major: 1,
+            minor: 3,
+            patch: 0,
+            pre: Default::default(),
+            build: Default::default(),
+        })
+    {
+        println!("cargo:rustc-cfg=xmlsec_1_3");
+    }
+
     println!("cargo:rustc-link-lib=xmlsec1-openssl"); // -lxmlsec1-openssl
     println!("cargo:rustc-link-lib=xmlsec1"); // -lxmlsec1
     println!("cargo:rustc-link-lib=xml2"); // -lxml2
     println!("cargo:rustc-link-lib=ssl"); // -lssl
     println!("cargo:rustc-link-lib=crypto"); // -lcrypto
 
-    if !path_bindings.exists() {
-        let pkgconfig = PkgConfig::new();
+    let pkgconfig = PkgConfig::new();
 
-        pkgconfig
-            .probe("xmlsec1")
-            .expect("Could not find xmlsec1 using pkg-config");
+    pkgconfig
+        .probe("xmlsec1")
+        .expect("Could not find xmlsec1 using pkg-config");
 
-        let openssl = pkgconfig
-            .probe("openssl")
-            .expect("Could not find openssl using pkg-config");
+    let openssl = pkgconfig
+        .probe("openssl")
+        .expect("Could not find openssl using pkg-config");
 
-        let bindbuild = BindgenBuilder::default()
-            .header("bindings.h")
-            .clang_args(cflags)
-            .clang_args(fetch_xmlsec_config_libs())
-            .clang_args(
-                openssl
-                    .include_paths
-                    .into_iter()
-                    .map(|p| format!("-I{}", p.display())),
-            )
-            .layout_tests(true)
-            .generate_comments(true);
+    let bindbuild = BindgenBuilder::default()
+        .header("bindings.h")
+        .clang_args(cflags)
+        .clang_args(fetch_xmlsec_config_libs())
+        .clang_args(
+            openssl
+                .include_paths
+                .into_iter()
+                .map(|p| format!("-I{}", p.display())),
+        )
+        .layout_tests(true)
+        .generate_comments(true);
 
-        let bindings = bindbuild.generate().expect("Unable to generate bindings");
+    let bindings = bindbuild.generate().expect("Unable to generate bindings");
 
-        bindings
-            .write_to_file(path_bindings)
-            .expect("Couldn't write bindings!");
-    }
+    bindings
+        .write_to_file(path_bindings)
+        .expect("Couldn't write bindings!");
+}
+
+fn fetch_xmlsec_version() -> semver::Version {
+    let out = Command::new("xmlsec1-config")
+        .arg("--version")
+        .output()
+        .expect("Failed to get --cflags from xmlsec1-config. Is xmlsec1 installed?")
+        .stdout;
+
+    semver::Version::parse(String::from_utf8(out).unwrap().trim_end())
+        .expect("failed to parse xmlsec version")
 }
 
 fn fetch_xmlsec_config_flags() -> Vec<String> {

--- a/bindings.rs
+++ b/bindings.rs
@@ -37,14 +37,26 @@ fn main() {
     println!("cargo:rustc-link-lib=crypto"); // -lcrypto
 
     if !path_bindings.exists() {
-        PkgConfig::new()
+        let pkgconfig = PkgConfig::new();
+
+        pkgconfig
             .probe("xmlsec1")
             .expect("Could not find xmlsec1 using pkg-config");
+
+        let openssl = pkgconfig
+            .probe("openssl")
+            .expect("Could not find openssl using pkg-config");
 
         let bindbuild = BindgenBuilder::default()
             .header("bindings.h")
             .clang_args(cflags)
             .clang_args(fetch_xmlsec_config_libs())
+            .clang_args(
+                openssl
+                    .include_paths
+                    .into_iter()
+                    .map(|p| format!("-I{}", p.display())),
+            )
             .layout_tests(true)
             .generate_comments(true);
 

--- a/src/xmlsec/xmlenc.rs
+++ b/src/xmlsec/xmlenc.rs
@@ -40,6 +40,7 @@ impl XmlSecEncryptionContext {
             return Err(XmlSecError::ContextInitError);
         }
 
+        #[cfg(xmlsec_1_3)]
         unsafe {
             (*ctx).keyInfoWriteCtx.flags |= bindings::XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH;
             (*ctx).keyInfoReadCtx.flags |= bindings::XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH;

--- a/src/xmlsec/xmlenc.rs
+++ b/src/xmlsec/xmlenc.rs
@@ -40,6 +40,11 @@ impl XmlSecEncryptionContext {
             return Err(XmlSecError::ContextInitError);
         }
 
+        unsafe {
+            (*ctx).keyInfoWriteCtx.flags |= bindings::XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH;
+            (*ctx).keyInfoReadCtx.flags |= bindings::XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH;
+        }
+
         Ok(Self { ctx })
     }
 

--- a/src/xmlsec/xmlenc.rs
+++ b/src/xmlsec/xmlenc.rs
@@ -40,6 +40,9 @@ impl XmlSecEncryptionContext {
             return Err(XmlSecError::ContextInitError);
         }
 
+        // xmlsec 1.3 changed how keys are discovered via the KeysMngr. The old default mode is
+        // now the "lax" mode that has to be explicitly enabled. This keeps the old behavior.
+        // https://github.com/lsh123/xmlsec/releases/tag/xmlsec_1_3_0
         #[cfg(xmlsec_1_3)]
         unsafe {
             (*ctx).keyInfoWriteCtx.flags |= bindings::XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH;


### PR DESCRIPTION
xmlsec 1.3.0 included a breaking change to how keys are discovered via the KeysMngr. What was previously the "default" method with an optional "strict" flag has been changed to strict-by-default with an optional "lax" flag. Existing code that depends on the old behavior will thus fail to find the keys for encryption and decryption. You can see this my nixpkgs update branch (#3).

This change makes it so that the xmlsec version is detected at build time, and if it's above 1.3.0, the lax flag gets enabled.

There's *probably* a more elegant solution to this that would satisfy both the old "strict" mode and the new "default" mode, but I wasn't able to figure it out with the limited xmlsec context I have.